### PR TITLE
Add support for parsing names and attributes in namespaces.

### DIFF
--- a/src/Xeno/SAX.hs
+++ b/src/Xeno/SAX.hs
@@ -253,7 +253,7 @@ isSpaceChar c = c == 32 || (c <= 10 && c >= 9) || c == 13
 -- | Is the character a valid tag name constituent?
 isNameChar :: Word8 -> Bool
 isNameChar c =
-  (c >= 97 && c <= 122) || (c >= 65 && c <= 90) || c == 95 || c == 45
+  (c >= 97 && c <= 122) || (c >= 65 && c <= 90) || c == 95 || c == 45 || c == 58
 {-# INLINE isNameChar #-}
 
 -- | Char for '\''.

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -37,7 +37,15 @@ spec =
           "attributes"
           (shouldBe
              (attributes (head (children $ fromRightE doc)))
-             [("id", "1"), ("extra", "2")]))
+             [("id", "1"), ("extra", "2")])
+        -- If this works without crashing we're happy.
+        let nsdoc = "<ns:tag os:attr=\"Namespaced attribute value\">Content.</ns:tag>"
+        it
+          "namespaces"
+          (shouldBe
+             (Xeno.SAX.validate nsdoc)
+             True)
+    )
 
 hexml_examples_sax :: [(Bool, ByteString)]
 hexml_examples_sax =


### PR DESCRIPTION
I need namespace support when I'm parsing xml files. This pull request adds it. 

The term support is maybe a too strong word in this context, the program doesn't actually handle namespaces, they are just funny names with colons in them, on the other hand the parser doesn't crash if
it encounters a colon in an attribute or name.