### PR TITLE
Added CDATA support and more verbose error messages.

### DIFF
--- a/src/Xeno/DOM.hs
+++ b/src/Xeno/DOM.hs
@@ -46,6 +46,7 @@ instance Show Node where
 data Content
   = Element {-# UNPACK #-}!Node
   | Text {-# UNPACK #-}!ByteString
+  | CData {-# UNPACK #-}!ByteString
   deriving (Show)
 
 -- | Get just element children of the node (no text).
@@ -82,6 +83,9 @@ contents (Node str start offsets) = collect firstChild
             collect (offsets ! (i + 4))
           0x01 ->
             Text (substring str (offsets ! (i + 1)) (offsets ! (i + 2))) :
+            collect (i + 3)
+          0x03 ->
+            CData (substring str (offsets ! (i + 1)) (offsets ! (i + 2))) :
             collect (i + 3)
           _ -> []
       | otherwise = []
@@ -195,6 +199,21 @@ parse str =
                  -- Pop the stack and return to the parent element.
                  previousParent <- UMV.read v (parent + 1)
                  writeRef parentRef previousParent)
+              (\(PS _ cdata_start cdata_len) -> do
+                 let tag = 0x03
+                 index <- readRef sizeRef
+                 v' <-
+                   do v <- readSTRef vecRef
+                      if index + 3 < UMV.length v
+                        then pure v
+                        else do
+                          v' <- UMV.grow v (UMV.length v)
+                          writeSTRef vecRef v'
+                          return v'
+                 do writeRef sizeRef (index + 3)
+                 do UMV.write v' index tag
+                    UMV.write v' (index + 1) cdata_start
+                    UMV.write v' (index + 2) cdata_len)
               str
             wet <- readSTRef vecRef
             arr <- UV.unsafeFreeze wet

--- a/src/Xeno/DOM.hs
+++ b/src/Xeno/DOM.hs
@@ -47,7 +47,7 @@ data Content
   = Element {-# UNPACK #-}!Node
   | Text {-# UNPACK #-}!ByteString
   | CData {-# UNPACK #-}!ByteString
-  deriving (Show)
+  deriving (Eq, Show)
 
 -- | Get just element children of the node (no text).
 children :: Node -> [Node]

--- a/src/Xeno/SAX.hs
+++ b/src/Xeno/SAX.hs
@@ -39,6 +39,7 @@ validate s =
                (\_ -> pure ())
                (\_ -> pure ())
                (\_ -> pure ())
+               (\_ -> pure ())
                s)) of
     Left (_ :: XenoException) -> False
     Right _ -> True
@@ -65,6 +66,9 @@ dump str =
           let !level' = level - 2
           put level'
           lift (S8.putStrLn (S8.replicate level' ' ' <> "</" <> name <> ">")))
+       (\cdata -> do
+          level <- get
+          lift (S8.putStrLn (S8.replicate level ' ' <> "CDATA: " <> S8.pack (show cdata))))
        str)
     (0 :: Int)
 
@@ -75,10 +79,11 @@ fold
   -> (s -> ByteString -> s) -- ^ End of open tag.
   -> (s -> ByteString -> s) -- ^ Text.
   -> (s -> ByteString -> s) -- ^ Close tag.
+  -> (s -> ByteString -> s) -- ^ CDATA.
   -> s
   -> ByteString
   -> Either XenoException s
-fold openF attrF endOpenF textF closeF s str =
+fold openF attrF endOpenF textF closeF cdataF s str =
   spork
     (execState
        (process
@@ -87,6 +92,7 @@ fold openF attrF endOpenF textF closeF s str =
           (\name -> modify (\s' -> endOpenF s' name))
           (\text -> modify (\s' -> textF s' text))
           (\name -> modify (\s' -> closeF s' name))
+          (\cdata -> modify (\s' -> cdataF s' cdata))
           str)
        s)
 
@@ -101,8 +107,9 @@ process
   -> (ByteString -> m ()) -- ^ End open tag.
   -> (ByteString -> m ()) -- ^ Text.
   -> (ByteString -> m ()) -- ^ Close tag.
+  -> (ByteString -> m ()) -- ^ CDATA.
   -> ByteString -> m ()
-process openF attrF endOpenF textF closeF str = findLT 0
+process openF attrF endOpenF textF closeF cdataF str = findLT 0
   where
     findLT index =
       case elemIndexFrom openTagChar str index of
@@ -112,16 +119,36 @@ process openF attrF endOpenF textF closeF str = findLT 0
           unless (S.null text) (textF text)
           checkOpenComment (fromLt + 1)
           where text = substring str index fromLt
+    -- Find open comment, CDATA or tag name.
     checkOpenComment index =
-      if s_index this 0 == bangChar &&
-         s_index this 1 == commentChar && s_index this 2 == commentChar
-        then findCommentEnd (index + 3)
-        else findTagName index
+      if | s_index this 0 == bangChar -- !
+           && s_index this 1 == commentChar -- -
+           && s_index this 2 == commentChar -> -- -
+           findCommentEnd (index + 3)
+         | s_index this 0 == bangChar -- !
+           && s_index this 1 == openAngleBracketChar -- [
+           && s_index this 2 == 67 -- C
+           && s_index this 3 == 68 -- D
+           && s_index this 4 == 65 -- A
+           && s_index this 5 == 84 -- T
+           && s_index this 6 == 65 -- A
+           && s_index this 7 == openAngleBracketChar -> -- [
+           case elemIndexFrom closeAngleBracketChar str (index + 8) of
+             Nothing -> throw (XenoParseError "Couldn't find closing angle bracket in CDATA.")
+             Just fromCloseAngleBracket ->
+               case elemIndexFrom closeAngleBracketChar str (fromCloseAngleBracket + 1) of
+                 Nothing ->
+                   throw (XenoParseError "Couldn't find second closing angle bracket in CDATA.")
+                 Just _ -> do
+                   cdataF (substring str (index + 8) fromCloseAngleBracket)
+                   findLT (fromCloseAngleBracket + 2) -- Start after ]]>
+         | otherwise ->
+           findTagName index
       where
         this = S.drop index str
     findCommentEnd index =
       case elemIndexFrom commentChar str index of
-        Nothing -> throw XenoParseError
+        Nothing -> throw (XenoParseError "Couldn't find the closing comment dash.")
         Just fromDash ->
           if s_index this 0 == commentChar && s_index this 1 == closeTagChar
             then findLT (fromDash + 2)
@@ -131,7 +158,7 @@ process openF attrF endOpenF textF closeF str = findLT 0
       let spaceOrCloseTag = parseName str index
       in if | s_index str index0 == questionChar ->
               case elemIndexFrom closeTagChar str spaceOrCloseTag of
-                Nothing -> throw XenoParseError
+                Nothing -> throw (XenoParseError "Couldn't find the end of the tag.")
                 Just fromGt -> do
                   findLT (fromGt + 1)
             | s_index str spaceOrCloseTag == closeTagChar ->
@@ -174,7 +201,7 @@ process openF attrF endOpenF textF closeF str = findLT 0
                                                str
                                                (quoteIndex + 1) of
                                           Nothing ->
-                                            throw XenoParseError
+                                            throw (XenoParseError "Couldn't find the matching quote character.")
                                           Just endQuoteIndex -> do
                                             attrF
                                               (substring str index afterAttrName)
@@ -183,8 +210,8 @@ process openF attrF endOpenF textF closeF str = findLT 0
                                                  (quoteIndex + 1)
                                                  (endQuoteIndex))
                                             findAttributes (endQuoteIndex + 1)
-                                   else throw XenoParseError
-                         else throw XenoParseError
+                                   else throw (XenoParseError ("Expected ' or \", got: " <> S.singleton usedChar))
+                         else throw (XenoParseError ("Expected =, got: " <> S.singleton (s_index str afterAttrName) <> " at character index: " <> (S8.pack . show) afterAttrName))
       where
         index = skipSpaces str index0
 {-# INLINE process #-}
@@ -193,14 +220,16 @@ process openF attrF endOpenF textF closeF str = findLT 0
                    (ByteString -> ByteString -> Identity ()) ->
                      (ByteString -> Identity ()) ->
                        (ByteString -> Identity ()) ->
-                         (ByteString -> Identity ()) -> ByteString -> Identity ()
+                         (ByteString -> Identity ()) ->
+                           (ByteString -> Identity ()) -> ByteString -> Identity ()
                #-}
 {-# SPECIALISE process ::
                  (ByteString -> IO ()) ->
                    (ByteString -> ByteString -> IO ()) ->
                      (ByteString -> IO ()) ->
                        (ByteString -> IO ()) ->
-                         (ByteString -> IO ()) -> ByteString -> IO ()
+                         (ByteString -> IO ()) ->
+                           (ByteString -> IO ()) -> ByteString -> IO ()
                #-}
 
 --------------------------------------------------------------------------------
@@ -280,7 +309,7 @@ slashChar = 47
 bangChar :: Word8
 bangChar = 33
 
--- | Open tag character.
+-- | The dash character.
 commentChar :: Word8
 commentChar = 45 -- '-'
 
@@ -291,3 +320,11 @@ openTagChar = 60 -- '<'
 -- | Close tag character.
 closeTagChar :: Word8
 closeTagChar = 62 -- '>'
+
+-- | Open angle bracket character.
+openAngleBracketChar :: Word8
+openAngleBracketChar = 91
+
+-- | Close angle bracket character.
+closeAngleBracketChar :: Word8
+closeAngleBracketChar = 93

--- a/src/Xeno/SAX.hs
+++ b/src/Xeno/SAX.hs
@@ -153,7 +153,7 @@ process openF attrF endOpenF textF closeF cdataF str = findLT 0
           if s_index str (fromCloseAngleBracket + 1) == closeAngleBracketChar
              then do
                cdataF (substring str cdata_start fromCloseAngleBracket)
-               findLT (fromCloseAngleBracket + 2) -- Start after ]]>
+               findLT (fromCloseAngleBracket + 3) -- Start after ]]>
              else
                -- We only found one ], that means that we need to keep searching.
                findCDataEnd cdata_start (fromCloseAngleBracket + 1)

--- a/src/Xeno/Types.hs
+++ b/src/Xeno/Types.hs
@@ -7,12 +7,13 @@ module Xeno.Types where
 
 import Control.DeepSeq
 import Control.Exception
+import Data.ByteString (ByteString)
 import Data.Typeable
 import GHC.Generics
 
 data XenoException
   = XenoStringIndexProblem
-  | XenoParseError
+  | XenoParseError ByteString
   | XenoExpectRootNode
   deriving (Show, Typeable, NFData, Generic)
 instance Exception XenoException where displayException = show


### PR DESCRIPTION
I needed CDATA support to parse Atom feeds, so I added it. I don't think this 
introduces any regressions when it comes to speed but I'm having a hard 
time testing it properly since Criterion says that the results always are 
severely inflated. Do you have a prefered way of testing to keep this library
superfast?

The CDATA is parsed and then handled in the same way as text is. It has
its own constructor in `Content`, and callbacks in suitable places.

The verbose error messages are implemented by giving the `XenoParseError` a
`ByteString` payload. This makes finding the limits of the parser much
easier, and it was very useful when I implemented the CDATA support.