### PR TITLE
Allow spaces around equals in attributes

### DIFF
--- a/src/Xeno/SAX.hs
+++ b/src/Xeno/SAX.hs
@@ -202,8 +202,9 @@ process openF attrF endOpenF textF closeF cdataF str = findLT 0
         else if s_index str index == closeTagChar
                then pure (Right index)
                else let afterAttrName = parseName str index
-                    in if s_index str afterAttrName == equalChar
-                         then let quoteIndex = afterAttrName + 1
+                        beforeEquals = skipSpaces str afterAttrName
+                    in if s_index str beforeEquals == equalChar
+                         then let quoteIndex = skipSpaces str (beforeEquals + 1)
                                   usedChar = s_index str quoteIndex
                               in if usedChar == quoteChar ||
                                     usedChar == doubleQuoteChar

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -46,7 +46,7 @@ spec = do
     "hexml tests"
     (do mapM_
           (\(v, i) -> it (show i) (shouldBe (validate i) v))
-          (hexml_examples_sax  ++ extra_examples_sax)
+          (hexml_examples_sax  ++ extra_examples_sax  ++ ws_around_equals_sax)
         mapM_
           (\(v, i) -> it (show i) (shouldBe (either (Left . show) (Right . id) (contents <$> parse i)) v))
           cdata_tests
@@ -74,6 +74,11 @@ extra_examples_sax =
     [(True, "<some-example/>")
     ,(True, "<a numeric1=\"attribute\"/>")
     ,(True, "<also.a.dot></also.a.dot>")
+    ]
+
+ws_around_equals_sax :: [(Bool, ByteString)]
+ws_around_equals_sax =
+    [(True, "<o  \nm   = \"100\"\n  gee =  \"0\">")
     ]
 
 -- | We want to make sure that the parser doesn't jump out of the CDATA


### PR DESCRIPTION
Things like
```
    <o m   = "100"
       gee =   "0">
```

are well-formed and appear in the wild.