### PR TITLE
Error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .stack-work
+_pier

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,12 @@ addons:
 # The different configurations we want to test. You could also do things like
 # change flags or use --stack-yaml to point to a different file.
 env:
-# - ARGS=""
-# - ARGS="--resolver lts"
 - ARGS="--resolver nightly"
+- ARGS="--resolver lts-12.18"
+- ARGS="--resolver lts-12.14"
+- ARGS="--resolver lts-11.22"
+- ARGS="--resolver lts-9.21"
+- ARGS="--resolver lts-7.24"
 - ARGS="--resolver lts-7.2"
 
 

--- a/pier.yaml
+++ b/pier.yaml
@@ -1,0 +1,10 @@
+# resolver: lts-7.24
+resolver: lts-11.8
+# resolver: nightly-2018-05-10
+packages:
+- .
+extra-deps:
+- hexpat-0.20.9
+- List-0.5.2
+- libxml-0.1.1
+- hexml

--- a/src/Xeno/Errors.hs
+++ b/src/Xeno/Errors.hs
@@ -8,6 +8,7 @@ module Xeno.Errors(printExceptions
                   ,failHere
                   ) where
 
+import           Data.Semigroup((<>))
 import qualified Data.ByteString.Char8 as BS hiding (elem)
 import           Data.ByteString.Internal(ByteString(..))
 import           System.IO(stderr)

--- a/src/Xeno/Errors.hs
+++ b/src/Xeno/Errors.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict            #-}
+{-# LANGUAGE ViewPatterns      #-}
+-- | Simplifies raising and presenting localized exceptions to the user.
+module Xeno.Errors(printExceptions
+                  ,displayException
+                  ,getStartIndex
+                  ,failHere
+                  ) where
+
+import qualified Data.ByteString.Char8 as BS hiding (elem)
+import           Data.ByteString.Internal(ByteString(..))
+import           System.IO(stderr)
+
+import           Xeno.Types
+
+{-# NOINLINE failHere #-}
+failHere :: BS.ByteString -> BS.ByteString -> Either XenoException a
+failHere msg here = Left $ XenoParseError (getStartIndex here) msg
+
+-- | Print schema errors with excerpts
+printExceptions :: BS.ByteString -> [XenoException] -> IO ()
+printExceptions i s = (BS.hPutStrLn stderr . displayException i) `mapM_` s
+
+-- | Find line number of the error from ByteString index.
+lineNo :: Int -> BS.ByteString -> Int
+lineNo index bs = BS.count '\n'
+                $ BS.take index bs
+
+-- | Show for ByteStrings
+bshow :: Show a => a -> BS.ByteString
+bshow = BS.pack . show
+
+{-# INLINE CONLIKE getStartIndex #-}
+getStartIndex :: BS.ByteString -> Int
+getStartIndex (PS _ from _) = from
+
+displayException :: BS.ByteString -> XenoException -> BS.ByteString
+displayException input (XenoParseError i msg) =
+               "Parse error in line " <> bshow (lineNo i input) <> ": "
+            <> msg
+            <> " at:\n"
+            <> lineContentBeforeError
+            <> lineContentAfterError
+            <> "\n" <> pointer
+  where
+    lineContentBeforeError = snd $ BS.spanEnd   eoln $ revTake 40 $ BS.take i input
+    lineContentAfterError  =       BS.takeWhile eoln $ BS.take 40 $ BS.drop i input
+    pointer                = BS.replicate (BS.length lineContentBeforeError) ' ' <> "^"
+    eoln ch                = ch /= '\n' && ch /= '\r'
+displayException _      err                        = bshow err
+
+-- | Take n last bytes.
+revTake :: Int -> BS.ByteString -> BS.ByteString
+revTake i (PS ptr from to) = PS ptr (end-len) len
+  where
+    end = from + to
+    len = min to i
+

--- a/xeno.cabal
+++ b/xeno.cabal
@@ -26,7 +26,7 @@ flag libxml2
 library
   hs-source-dirs: src
   ghc-options: -Wall -O2
-  exposed-modules: Xeno.SAX, Xeno.DOM, Xeno.Types
+  exposed-modules: Xeno.SAX, Xeno.DOM, Xeno.Types, Xeno.Errors
   other-modules: Control.Spork
   build-depends: base >= 4.7 && < 5
                , bytestring, vector, deepseq, array, mutable-containers, mtl


### PR DESCRIPTION
Here is a patch with functions that show `XenoParseException` in a nice format for end-user debugging:
```
Parse error in line 318: unknown attribute 'xbase'
      <xs:extension xbase="creditRecordCounts">
                         ^
```