### PR TITLE
Dom recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .stack-work
 _pier
+*.hi
+*.o

--- a/bench/Memory.hs
+++ b/bench/Memory.hs
@@ -10,6 +10,7 @@ import qualified Data.ByteString as S
 import qualified Text.XML.Hexml as Hexml
 import           Weigh
 import qualified Xeno.DOM
+import qualified Xeno.RobustDOM
 import qualified Xeno.SAX
 
 main :: IO ()
@@ -21,12 +22,15 @@ main = do
     (do func "4kb/hexml/dom" Hexml.parse f4kb
         func "4kb/xeno/sax" Xeno.SAX.validate f4kb
         func "4kb/xeno/dom" Xeno.DOM.parse f4kb
+        func "4kb/xeno/dom-with-recovery" Xeno.RobustDOM.parse f4kb
         func "31kb/hexml/dom" Hexml.parse f31kb
         func "31kb/xeno/sax" Xeno.SAX.validate f31kb
         func "31kb/xeno/dom" Xeno.DOM.parse f31kb
+        func "31kb/xeno/dom-with-recovery" Xeno.RobustDOM.parse f31kb
         func "211kb/hexml/dom" Hexml.parse f211kb
         func "211kb/xeno/sax" Xeno.SAX.validate f211kb
-        func "211kb/xeno/dom" Xeno.DOM.parse f211kb)
+        func "211kb/xeno/dom" Xeno.DOM.parse f211kb
+        func "211kb/xeno/dom-with-recovery" Xeno.RobustDOM.parse f211kb)
 
 instance NFData Hexml.Node where
   rnf !_ = ()

--- a/bench/Speed.hs
+++ b/bench/Speed.hs
@@ -21,6 +21,7 @@ import           Text.XML.Light as XML
 import           Text.XML.Light.Input as XML
 import qualified Xeno.SAX
 import qualified Xeno.DOM
+import qualified Xeno.RobustDOM
 #ifdef LIBXML2
 import qualified Text.XML.LibXML.Parser as Libxml2
 #endif
@@ -36,6 +37,7 @@ main =
              [ bench "hexml-dom" (whnf Hexml.parse input)
              , bench "xeno-sax" (whnf Xeno.SAX.validate input)
              , bench "xeno-dom" (whnf Xeno.DOM.parse input)
+             , bench "xeno-dom-with-recovery" (whnf Xeno.RobustDOM.parse input)
              , bench
                  "hexpat-sax"
                  (whnf
@@ -60,6 +62,7 @@ main =
              [ bench "hexml-dom" (whnf Hexml.parse input)
              , bench "xeno-sax" (whnf Xeno.SAX.validate input)
              , bench "xeno-dom" (whnf Xeno.DOM.parse input)
+             , bench "xeno-dom-with-recovery" (whnf Xeno.RobustDOM.parse input)
              , bench
                  "hexpat-sax"
                  (nf
@@ -85,6 +88,7 @@ main =
              [ bench "hexml-dom" (whnf Hexml.parse input)
              , bench "xeno-sax" (whnf Xeno.SAX.validate input)
              , bench "xeno-dom" (whnf Xeno.DOM.parse input)
+             , bench "xeno-dom-with-recovery" (whnf Xeno.RobustDOM.parse input)
              , bench
                  "hexpat-sax"
                  (nf

--- a/src/Xeno/DOM.hs
+++ b/src/Xeno/DOM.hs
@@ -48,7 +48,7 @@ parse str =
           -- skipping text assuming that it contains only white space
           -- characters
           Just 0x1 -> go (n+3)
-          _ -> Nothing
+          _        -> Nothing
     PS _ offset0 _ = str
     node =
       runST

--- a/src/Xeno/DOM.hs
+++ b/src/Xeno/DOM.hs
@@ -29,102 +29,10 @@ import qualified Data.Vector.Unboxed as UV
 import qualified Data.Vector.Unboxed.Mutable as UMV
 import           Xeno.SAX
 import           Xeno.Types
+import           Xeno.DOM.Internal
 
-import Debug.Trace
-
--- | Some XML nodes.
-data Node = Node !ByteString !Int !(UV.Vector Int)
-  deriving (Eq, Data, Typeable)
-
-instance NFData Node where
-  rnf !_ = ()
-
-instance Show Node where
-  show n =
-    "(Node " ++
-    show (name n) ++
-    " " ++ show (attributes n) ++ " " ++ show (contents n) ++ ")"
-
--- | Content of a node.
-data Content
-  = Element {-# UNPACK #-}!Node
-  | Text {-# UNPACK #-}!ByteString
-  | CData {-# UNPACK #-}!ByteString
-  deriving (Eq, Show, Data, Typeable)
-
-instance NFData Content where
-  rnf !_ = ()
-
--- | Get just element children of the node (no text).
-children :: Node -> [Node]
-children (Node str start offsets) = collect firstChild
-  where
-    collect i
-      | i < endBoundary =
-        case offsets ! i of
-          0x00 -> Node str i offsets : collect (offsets ! (i + 4))
-          0x01 -> collect (i + 3)
-          off -> trace ("Offsets " <> show i <> " is " <> show off) []
-      | otherwise = []
-    firstChild = go (start + 5)
-      where
-        go i
-          | i < endBoundary =
-            case offsets ! i of
-              0x02 -> go (i + 5)
-              _ -> i
-          | otherwise = i
-    endBoundary = offsets ! (start + 4)
-
--- | Contents of a node.
-contents :: Node -> [Content]
-contents (Node str start offsets) = collect firstChild
-  where
-    collect i
-      | i < endBoundary =
-        case offsets ! i of
-          0x00 ->
-            Element
-              (Node str i offsets) :
-            collect (offsets ! (i + 4))
-          0x01 ->
-            Text (substring str (offsets ! (i + 1)) (offsets ! (i + 2))) :
-            collect (i + 3)
-          0x03 ->
-            CData (substring str (offsets ! (i + 1)) (offsets ! (i + 2))) :
-            collect (i + 3)
-          _ -> []
-      | otherwise = []
-    firstChild = go (start + 5)
-      where
-        go i | i < endBoundary =
-          case offsets ! i of
-            0x02 -> go (i + 5)
-            _ -> i
-          | otherwise = i
-    endBoundary = offsets ! (start + 4)
-
--- | Attributes of a node.
-attributes :: Node -> [(ByteString,ByteString)]
-attributes (Node str start offsets) = collect (start + 5)
-  where
-    collect i
-      | i < endBoundary =
-        case offsets ! i of
-          0x02 ->
-            ( substring str (offsets ! (i + 1)) (offsets ! (i + 2))
-            , substring str (offsets ! (i + 3)) (offsets ! (i + 4))) :
-            collect (i + 5)
-          _ -> []
-      | otherwise = []
-    endBoundary = offsets ! (start + 4)
-
--- | Name of the element.
-name :: Node -> ByteString
-name (Node str start offsets) =
-  case offsets ! start of
-    0x00 -> substring str (offsets ! (start + 2)) (offsets ! (start + 3))
-    _ -> error "Node cannot have empty name" -- mempty
+--import Debug.Trace
+trace _ a = a
 
 -- | Parse a complete Nodes document.
 parse :: ByteString -> Either XenoException Node
@@ -235,7 +143,3 @@ parse str =
             size <- readRef sizeRef
             return (UV.unsafeSlice 0 size arr))
 
--- | Get a substring of the BS.
-substring :: ByteString -> Int -> Int -> ByteString
-substring s' start len = S.take len (S.drop start s')
-{-# INLINE substring #-}

--- a/src/Xeno/DOM.hs
+++ b/src/Xeno/DOM.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
 -- | DOM parser and API for XML.
 
 module Xeno.DOM
@@ -18,12 +18,13 @@ module Xeno.DOM
 import           Control.DeepSeq
 import           Control.Monad.ST
 import           Control.Spork
-import           Data.ByteString (ByteString)
+import           Data.ByteString          (ByteString)
 import qualified Data.ByteString as S
 import           Data.ByteString.Internal (ByteString(PS))
+import           Data.Data                (Data, Typeable)
 import           Data.Mutable
 import           Data.STRef
-import           Data.Vector.Unboxed ((!))
+import           Data.Vector.Unboxed      ((!))
 import qualified Data.Vector.Unboxed as UV
 import qualified Data.Vector.Unboxed.Mutable as UMV
 import           Xeno.SAX
@@ -31,7 +32,7 @@ import           Xeno.Types
 
 -- | Some XML nodes.
 data Node = Node !ByteString !Int !(UV.Vector Int)
-  deriving (Eq)
+  deriving (Eq, Data, Typeable)
 
 instance NFData Node where
   rnf !_ = ()
@@ -47,7 +48,10 @@ data Content
   = Element {-# UNPACK #-}!Node
   | Text {-# UNPACK #-}!ByteString
   | CData {-# UNPACK #-}!ByteString
-  deriving (Eq, Show)
+  deriving (Eq, Show, Data, Typeable)
+
+instance NFData Content where
+  rnf !_ = ()
 
 -- | Get just element children of the node (no text).
 children :: Node -> [Node]

--- a/src/Xeno/DOM.hs
+++ b/src/Xeno/DOM.hs
@@ -31,15 +31,12 @@ import           Xeno.SAX
 import           Xeno.Types
 import           Xeno.DOM.Internal
 
---import Debug.Trace
-trace _ a = a
-
 -- | Parse a complete Nodes document.
 parse :: ByteString -> Either XenoException Node
 parse str =
   case spork node of
     Left e -> Left e
-    Right r ->  trace ("offset array: " <> show r) $
+    Right r ->
       case findRootNode r of
         Just n -> Right n
         Nothing -> Left XenoExpectRootNode

--- a/src/Xeno/DOM/Internal.hs
+++ b/src/Xeno/DOM/Internal.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+-- | Efficient DOM data structure
+module Xeno.DOM.Internal
+  ( Node(..)
+  , Content(..)
+  , name
+  , attributes
+  , contents
+  , children
+  ) where
+
+import           Control.DeepSeq
+import           Control.Monad.ST
+import           Control.Spork
+import           Data.ByteString          (ByteString)
+import qualified Data.ByteString as S
+import           Data.ByteString.Internal (ByteString(PS))
+import           Data.Data                (Data, Typeable)
+import           Data.Mutable
+import           Data.STRef
+import           Data.Vector.Unboxed      ((!))
+import qualified Data.Vector.Unboxed as UV
+import qualified Data.Vector.Unboxed.Mutable as UMV
+import           Xeno.SAX
+import           Xeno.Types
+
+--import Debug.Trace
+trace _ a = a
+
+-- | Some XML nodes.
+data Node = Node !ByteString !Int !(UV.Vector Int)
+  deriving (Eq, Data, Typeable)
+
+instance NFData Node where
+  rnf !_ = ()
+
+instance Show Node where
+  show n =
+    "(Node " ++
+    show (name n) ++
+    " " ++ show (attributes n) ++ " " ++ show (contents n) ++ ")"
+
+-- | Content of a node.
+data Content
+  = Element {-# UNPACK #-}!Node
+  | Text {-# UNPACK #-}!ByteString
+  | CData {-# UNPACK #-}!ByteString
+  deriving (Eq, Show, Data, Typeable)
+
+instance NFData Content where
+  rnf !_ = ()
+
+-- | Get just element children of the node (no text).
+children :: Node -> [Node]
+children (Node str start offsets) = collect firstChild
+  where
+    collect i
+      | i < endBoundary =
+        case offsets ! i of
+          0x00 -> Node str i offsets : collect (offsets ! (i + 4))
+          0x01 -> collect (i + 3)
+          off -> trace ("Offsets " <> show i <> " is " <> show off) []
+      | otherwise = []
+    firstChild = go (start + 5)
+      where
+        go i
+          | i < endBoundary =
+            case offsets ! i of
+              0x02 -> go (i + 5)
+              _ -> i
+          | otherwise = i
+    endBoundary = offsets ! (start + 4)
+
+-- | Contents of a node.
+contents :: Node -> [Content]
+contents (Node str start offsets) = collect firstChild
+  where
+    collect i
+      | i < endBoundary =
+        case offsets ! i of
+          0x00 ->
+            Element
+              (Node str i offsets) :
+            collect (offsets ! (i + 4))
+          0x01 ->
+            Text (substring str (offsets ! (i + 1)) (offsets ! (i + 2))) :
+            collect (i + 3)
+          0x03 ->
+            CData (substring str (offsets ! (i + 1)) (offsets ! (i + 2))) :
+            collect (i + 3)
+          _ -> []
+      | otherwise = []
+    firstChild = go (start + 5)
+      where
+        go i | i < endBoundary =
+          case offsets ! i of
+            0x02 -> go (i + 5)
+            _ -> i
+          | otherwise = i
+    endBoundary = offsets ! (start + 4)
+
+-- | Attributes of a node.
+attributes :: Node -> [(ByteString,ByteString)]
+attributes (Node str start offsets) = collect (start + 5)
+  where
+    collect i
+      | i < endBoundary =
+        case offsets ! i of
+          0x02 ->
+            ( substring str (offsets ! (i + 1)) (offsets ! (i + 2))
+            , substring str (offsets ! (i + 3)) (offsets ! (i + 4))) :
+            collect (i + 5)
+          _ -> []
+      | otherwise = []
+    endBoundary = offsets ! (start + 4)
+
+-- | Name of the element.
+name :: Node -> ByteString
+name (Node str start offsets) =
+  case offsets ! start of
+    0x00 -> substring str (offsets ! (start + 2)) (offsets ! (start + 3))
+    _ -> error "Node cannot have empty name" -- mempty
+
+-- | Get a substring of the BS.
+substring :: ByteString -> Int -> Int -> ByteString
+substring s' start len = S.take len (S.drop start s')
+{-# INLINE substring #-}

--- a/src/Xeno/DOM/Internal.hs
+++ b/src/Xeno/DOM/Internal.hs
@@ -14,10 +14,9 @@ module Xeno.DOM.Internal
   ) where
 
 import           Control.DeepSeq
-import           Control.Monad.ST
 import           Data.ByteString          (ByteString)
 import qualified Data.ByteString as S
-import           Data.ByteString.Internal (ByteString(PS))
+import           Data.ByteString.Internal (ByteString(..))
 import           Data.Data                (Data, Typeable)
 import           Data.Mutable
 import           Data.STRef
@@ -60,7 +59,7 @@ children (Node str start offsets) = collect firstChild
         case offsets ! i of
           0x00 -> Node str i offsets : collect (offsets ! (i + 4))
           0x01 -> collect (i + 3)
-          off -> [] -- trace ("Offsets " <> show i <> " is " <> show off) []
+          _off -> [] -- trace ("Offsets " <> show i <> " is " <> show off) []
       | otherwise = []
     firstChild = go (start + 5)
       where

--- a/src/Xeno/DOM/Internal.hs
+++ b/src/Xeno/DOM/Internal.hs
@@ -26,10 +26,9 @@ import           Data.Vector.Unboxed      ((!))
 import qualified Data.Vector.Unboxed as UV
 import qualified Data.Vector.Unboxed.Mutable as UMV
 import           Xeno.SAX
-import           Xeno.Types
 
 --import Debug.Trace
-trace _ a = a
+--trace _ a = a
 
 -- | Some XML nodes.
 data Node = Node !ByteString !Int !(UV.Vector Int)
@@ -63,7 +62,7 @@ children (Node str start offsets) = collect firstChild
         case offsets ! i of
           0x00 -> Node str i offsets : collect (offsets ! (i + 4))
           0x01 -> collect (i + 3)
-          off -> trace ("Offsets " <> show i <> " is " <> show off) []
+          off -> [] -- trace ("Offsets " <> show i <> " is " <> show off) []
       | otherwise = []
     firstChild = go (start + 5)
       where

--- a/src/Xeno/DOM/Internal.hs
+++ b/src/Xeno/DOM/Internal.hs
@@ -15,7 +15,6 @@ module Xeno.DOM.Internal
 
 import           Control.DeepSeq
 import           Control.Monad.ST
-import           Control.Spork
 import           Data.ByteString          (ByteString)
 import qualified Data.ByteString as S
 import           Data.ByteString.Internal (ByteString(PS))
@@ -25,7 +24,6 @@ import           Data.STRef
 import           Data.Vector.Unboxed      ((!))
 import qualified Data.Vector.Unboxed as UV
 import qualified Data.Vector.Unboxed.Mutable as UMV
-import           Xeno.SAX
 
 --import Debug.Trace
 --trace _ a = a

--- a/src/Xeno/DOM/Robust.hs
+++ b/src/Xeno/DOM/Robust.hs
@@ -32,7 +32,7 @@ import           Xeno.DOM.Internal(Node(..), Content(..), name, attributes, cont
 
 -- | Parse a complete Nodes document.
 parse :: ByteString -> Either XenoException Node
-parse str =
+parse inp =
   case spork node of
     Left e -> Left e
     Right r ->
@@ -49,12 +49,13 @@ parse str =
           Just 0x1 -> go (n+3)
           _ -> Nothing
     PS _ offset0 _ = str
+    str = skipDoctype inp
     node =
       runST
         (do nil <- UMV.new 1000
-            vecRef <- newSTRef nil
-            sizeRef <- fmap asURef (newRef 0)
-            parentRef <- fmap asURef (newRef 0)
+            vecRef    <- newSTRef nil
+            sizeRef   <- fmap asURef $ newRef 0
+            parentRef <- fmap asURef $ newRef 0
             process
               (\(PS _ name_start name_len) -> do
                  let tag = 0x00

--- a/src/Xeno/SAX.hs
+++ b/src/Xeno/SAX.hs
@@ -24,6 +24,8 @@ import           Data.Monoid
 import           Data.Word
 import           Xeno.Types
 
+import Debug.Trace
+
 --------------------------------------------------------------------------------
 -- Helpful interfaces to the parser
 
@@ -132,7 +134,8 @@ process openF attrF endOpenF textF closeF cdataF str = findLT 0
       if | s_index this 0 == bangChar -- !
            && s_index this 1 == commentChar -- -
            && s_index this 2 == commentChar -> -- -
-           findCommentEnd (index + 3)
+           trace ("Found comment " <> show (S.take 10 $ S.drop (index-1) str)) $ 
+             findCommentEnd (index + 3)
          | s_index this 0 == bangChar -- !
            && s_index this 1 == openAngleBracketChar -- [
            && s_index this 2 == 67 -- C
@@ -151,8 +154,12 @@ process openF attrF endOpenF textF closeF cdataF str = findLT 0
         Nothing -> throw $ XenoParseError index "Couldn't find the closing comment dash."
         Just fromDash ->
           if s_index this 0 == commentChar && s_index this 1 == closeTagChar
-            then findLT (fromDash + 2)
-            else findCommentEnd (fromDash + 1)
+            then trace ("Closed comment! "   <> show (S.take 10 $ S.drop (index-1)    str )
+                     <> " going for: "       <> show (S.take 10 $ S.drop (fromDash+1) str )) $
+                       findLT (fromDash + 2)
+            else trace ("Unclosed comment: " <> show (S.take 10 $ S.drop (index-1)    str )
+                     <> " going for: "       <> show (S.take 10 $ S.drop  fromDash    str )) $
+                       findCommentEnd (fromDash + 1)
           where this = S.drop index str
     findCDataEnd cdata_start index =
       case elemIndexFrom closeAngleBracketChar str index of

--- a/src/Xeno/SAX.hs
+++ b/src/Xeno/SAX.hs
@@ -10,6 +10,7 @@ module Xeno.SAX
   , fold
   , validate
   , dump
+  , skipDoctype
   ) where
 
 import           Control.Exception
@@ -19,6 +20,7 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Unsafe as SU
+import           Data.Char(isSpace)
 import           Data.Functor.Identity
 import           Data.Monoid
 import           Data.Word
@@ -364,3 +366,19 @@ openAngleBracketChar = 91
 -- | Close angle bracket character.
 closeAngleBracketChar :: Word8
 closeAngleBracketChar = 93
+
+-- | Skip initial DOCTYPE declaration
+skipDoctype :: ByteString -> ByteString
+skipDoctype arg =
+    if "<!DOCTYPE" `S8.isPrefixOf` bs
+      then let (_, rest)=">" `S8.breakSubstring` bs
+           in skipSpaces $ S8.drop 1 rest
+      else bs
+  where
+    bs = skipSpaces arg
+    skipSpaces = S8.dropWhile isSpace
+    {-withoutXML = if "<?" `S8.isPrefixOf` skipSpaces withoutDoctype
+      then let (_, rest)="?>" `S8.breakSubstring` withoutDoctype
+           in skipSpaces $ S8.drop 2 rest
+      else  bs-}
+

--- a/src/Xeno/Tree.hs
+++ b/src/Xeno/Tree.hs
@@ -4,7 +4,7 @@
 
 -- | Using the SAX parser, provide a simple tree interface.
 
-module Xeno.Tree where
+module Xeno.Tree(Node(..), render, parse) where
 
 import Control.DeepSeq
 import Data.ByteString (ByteString)

--- a/src/Xeno/Types.hs
+++ b/src/Xeno/Types.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric      #-}
 
 -- | Shared types.
 
@@ -8,6 +9,7 @@ module Xeno.Types where
 import Control.DeepSeq
 import Control.Exception
 import Data.ByteString (ByteString)
+import Data.Data
 import Data.Typeable
 import GHC.Generics
 
@@ -15,7 +17,7 @@ data XenoException
   = XenoStringIndexProblem { stringIndex :: Int, inputString :: ByteString }
   | XenoParseError         { inputIndex  :: Int, message     :: ByteString }
   | XenoExpectRootNode
-  deriving (Show, Typeable, NFData, Generic)
+  deriving (Show, Data, Typeable, NFData, Generic)
 
 instance Exception XenoException where displayException = show
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,3 @@
-# resolver: lts-7.24
-# resolver: lts-11.8
-# resolver: nightly-2018-05-10
 resolver: lts-12.20
 packages:
 - .

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -131,12 +131,10 @@ spec = do
             validate nsdoc `shouldBe` True
       )
     it "recovers unclosed tag" $ do
-      let parsed = RDOM.parse "<a attr='a'><img></img></a>"
-      True `shouldBe` True
+      let parsed = RDOM.parse "<a attr='a'><img></a>"
       Debug.trace (show parsed) $ do
         name (fromRightE parsed) `shouldBe` "a"
-        RDOM.attributes (fromRightE parsed) `shouldBe` []
-        RDOM.children   (fromRightE parsed) `shouldBe` []
+        RDOM.attributes (fromRightE parsed) `shouldBe` [("attr", "a")]
         map name (RDOM.children $ fromRightE parsed) `shouldBe` ["img"]
     it "ignores too many closing tags" $ do
       let parsed = RDOM.parse "<a></a></b></c>"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -10,7 +10,7 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import           Test.Hspec
 --import qualified Test.Hspec as Hspec(it)
-import           Xeno.SAX  (validate)
+import           Xeno.SAX  (validate, skipDoctype)
 import           Xeno.DOM  (Content(..), parse, name, contents, attributes, children)
 import qualified Xeno.DOM.Robust as RDOM
 import           Xeno.Types
@@ -67,10 +67,6 @@ spec = do
       let docWithPrologue = "<?xml version=\"1.1\"?>\n<greeting>Hello, world!</greeting>"
           parsedRoot = fromRightE $ Xeno.DOM.parse docWithPrologue
       name parsedRoot `shouldBe` "greeting"                
-    it "html doctype test" $ do
-      let docWithPrologue = "<!DOCTYPE html>\n<greeting>Hello, world!</greeting>"
-          parsedRoot = fromRightE $ Xeno.DOM.parse docWithPrologue
-      name parsedRoot `shouldBe` "greeting"
       
   describe
     "hexml tests"
@@ -139,6 +135,14 @@ spec = do
     it "ignores too many closing tags" $ do
       let parsed = RDOM.parse "<a></a></b></c>"
       isRight parsed `shouldBe` True
+  describe "skipDoctype" $ do
+    it "strips initial doctype declaration" $ do
+      skipDoctype "<!DOCTYPE html><?xml version=\"1.0\" encoding=\"UTF-8\"?>Hello" `shouldBe` "<?xml version=\"1.0\" encoding=\"UTF-8\"?>Hello"
+    it "strips doctype after spaces" $ do
+      skipDoctype "  \n<!DOCTYPE html><?xml version=\"1.0\" encoding=\"UTF-8\"?>Hello" `shouldBe` "<?xml version=\"1.0\" encoding=\"UTF-8\"?>Hello"
+    it "does not strip anything after or inside element" $ do
+      let insideElt = "<xml><?xml version=\"1.0\" encoding=\"UTF-8\"?>Hello</xml>"
+      skipDoctype  insideElt `shouldBe` insideElt
 
 hexml_examples_sax :: [(Bool, ByteString)]
 hexml_examples_sax =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Simple test suite.
@@ -8,13 +9,38 @@ import           Data.Either (isRight)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import           Test.Hspec
-import           Xeno.SAX (validate)
-import           Xeno.DOM (Content(..), parse, name, contents, attributes, children)
+--import qualified Test.Hspec as Hspec(it)
+import           Xeno.SAX  (validate)
+import           Xeno.DOM  (Content(..), parse, name, contents, attributes, children)
+import qualified Xeno.RobustDOM as RDOM
 import           Xeno.Types
-
+import           System.Timeout
+import qualified Debug.Trace as Debug(trace)
 
 main :: IO ()
 main = hspec spec
+
+{-
+withinTime  :: (HasCallStack) => Int -> IO Expectation -> Expectation
+withinTime t action = do
+  r <- timeout  t action
+  case r of
+    Just !r  -> r
+    Nothing -> expectationFailure $ "did not finish within allocated time"
+ -}
+
+{-
+timedAction action = do
+    timeout (return $! action)
+  where
+    check a = 
+ -}
+
+{-
+it :: Example a => String -> a -> SpecWith (Arg a)
+it s = Hspec.it s . withinTime (5*second) . pure
+  where
+    second = 1000000-}
 
 spec :: SpecWith ()
 spec = do
@@ -30,7 +56,7 @@ spec = do
     let doc =
               parse
                 "<root><test id=\"1\" extra=\"2\" />\n<test id=\"2\" /><b><test id=\"3\" /></b><test id=\"4\" /><test /></root>"
-                
+
     it "children test" $
       map name (children $ fromRightE doc) `shouldBe` ["test", "test", "b", "test", "test"]
       
@@ -41,6 +67,10 @@ spec = do
       let docWithPrologue = "<?xml version=\"1.1\"?>\n<greeting>Hello, world!</greeting>"
           parsedRoot = fromRightE $ Xeno.DOM.parse docWithPrologue
       name parsedRoot `shouldBe` "greeting"                
+    it "html doctype test" $ do
+      let docWithPrologue = "<!DOCTYPE html>\n<greeting>Hello, world!</greeting>"
+          parsedRoot = fromRightE $ Xeno.DOM.parse docWithPrologue
+      name parsedRoot `shouldBe` "greeting"
       
   describe
     "hexml tests"
@@ -57,6 +87,60 @@ spec = do
           "namespaces" $
           validate nsdoc `shouldBe` True
     )
+  describe "robust XML tests" $ do
+    it "DOM from bytestring substring" $ do
+        let substr = BS.drop 5 "5<8& <valid>xml<here/></valid>"
+            parsedRoot = fromRightE $ RDOM.parse substr
+        name parsedRoot `shouldBe` "valid"
+
+    it "Leading whitespace characters are accepted by parse" $ 
+      isRight (RDOM.parse "\n<a></a>") `shouldBe` True
+
+    let doc =
+              RDOM.parse
+                "<root><test id=\"1\" extra=\"2\" />\n<test id=\"2\" /><b><test id=\"3\" /></b><test id=\"4\" /><test /></root>"
+
+    it "children test" $
+      map name (children $ fromRightE doc) `shouldBe` ["test", "test", "b", "test", "test"]
+      
+    it "attributes" $ 
+      attributes (head (children $ fromRightE doc)) `shouldBe` [("id", "1"), ("extra", "2")]
+
+    it "xml prologue test" $ do
+      let docWithPrologue = "<?xml version=\"1.1\"?>\n<greeting>Hello, world!</greeting>"
+          parsedRoot = fromRightE $ RDOM.parse docWithPrologue
+      name parsedRoot `shouldBe` "greeting"                
+    it "html doctype test" $ do
+      let docWithPrologue = "<!DOCTYPE html>\n<greeting>Hello, world!</greeting>"
+          parsedRoot = fromRightE $ RDOM.parse docWithPrologue
+      name parsedRoot `shouldBe` "greeting"
+       
+    describe
+      "hexml tests"
+      (do mapM_
+            (\(v, i) -> it (show i) (shouldBe (validate i) v))
+            (hexml_examples_sax  ++ extra_examples_sax)
+          mapM_
+            (\(v, i) -> it (show i) (shouldBe (either (Left . show) (Right . id) (contents <$> parse i)) v))
+            cdata_tests
+   
+         -- If this works without crashing we're happy.
+          let nsdoc = "<ns:tag os:attr=\"Namespaced attribute value\">Content.</ns:tag>"
+          it
+            "namespaces" $
+            validate nsdoc `shouldBe` True
+      )
+    it "recovers unclosed tag" $ do
+      let parsed = RDOM.parse "<a attr='a'><img></img></a>"
+      True `shouldBe` True
+      Debug.trace (show parsed) $ do
+        name (fromRightE parsed) `shouldBe` "a"
+        RDOM.attributes (fromRightE parsed) `shouldBe` []
+        RDOM.children   (fromRightE parsed) `shouldBe` []
+        map name (RDOM.children $ fromRightE parsed) `shouldBe` ["img"]
+    it "ignores too many closing tags" $ do
+      let parsed = RDOM.parse "<a></a></b></c>"
+      isRight parsed `shouldBe` True
 
 hexml_examples_sax :: [(Bool, ByteString)]
 hexml_examples_sax =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -12,7 +12,7 @@ import           Test.Hspec
 --import qualified Test.Hspec as Hspec(it)
 import           Xeno.SAX  (validate)
 import           Xeno.DOM  (Content(..), parse, name, contents, attributes, children)
-import qualified Xeno.RobustDOM as RDOM
+import qualified Xeno.DOM.Robust as RDOM
 import           Xeno.Types
 import           System.Timeout
 import qualified Debug.Trace as Debug(trace)

--- a/xeno.cabal
+++ b/xeno.cabal
@@ -32,12 +32,11 @@ library
                , bytestring
                , vector
                , deepseq
-               , array
                , mutable-containers
                , mtl
                -- , exceptions
                -- | DEBUG 
-               , hspec
+               -- , hspec
   default-language: Haskell2010
 
 test-suite xeno-test
@@ -46,8 +45,6 @@ test-suite xeno-test
   hs-source-dirs: test
   main-is: Main.hs
   build-depends: base, xeno, hexml, hspec, bytestring
-               -- | DEBUG 
-               , hspec
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language: Haskell2010
 

--- a/xeno.cabal
+++ b/xeno.cabal
@@ -27,7 +27,7 @@ library
   hs-source-dirs: src
   ghc-options: -Wall -O2
   exposed-modules: Xeno.SAX, Xeno.DOM, Xeno.Types, Xeno.Errors, Xeno.RobustDOM
-  other-modules: Control.Spork
+  other-modules: Control.Spork, Xeno.DOM.Internal 
   build-depends: base >= 4.7 && < 5
                , bytestring
                , vector

--- a/xeno.cabal
+++ b/xeno.cabal
@@ -26,7 +26,7 @@ flag libxml2
 library
   hs-source-dirs: src
   ghc-options: -Wall -O2
-  exposed-modules: Xeno.SAX, Xeno.DOM, Xeno.Types, Xeno.Errors
+  exposed-modules: Xeno.SAX, Xeno.DOM, Xeno.Types, Xeno.Errors, Xeno.RobustDOM
   other-modules: Control.Spork
   build-depends: base >= 4.7 && < 5
                , bytestring


### PR DESCRIPTION
This PR adds `Xeno.Dom.Robust` interface that automatically closes XML elements if the closing tag is not found. Extremely useful for HTML parsing. Additionally it provides a function to skip doctype.

`Xeno.DOM.Robust` is only slightly slower than old version, so I suggest use it on all HTML documents, and those XML documents that are not strict in their conformance to the standard.