### PR TITLE
Introduce a whitespace-around-equals CPP flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ addons:
 # change flags or use --stack-yaml to point to a different file.
 env:
 - ARGS="--resolver lts"
+- ARGS="--resolver lts --flag xeno:whitespace-around-equals"
 - ARGS="--resolver nightly"
 - ARGS="--resolver lts-7.2"
-
 
 before_install:
 # Download and unpack the stack executable

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 # executables, and test suites, and runs the test suites. --no-terminal works
 # around some quirks in Travis's terminal implementation.
 script:
-  - stack $ARGS --no-terminal --install-ghc test --haddock
+  - stack --no-terminal --install-ghc test $ARGS --haddock
 
 # Caching so the next build will be fast too.
 cache:

--- a/src/Xeno/SAX.hs
+++ b/src/Xeno/SAX.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -202,9 +203,14 @@ process openF attrF endOpenF textF closeF cdataF str = findLT 0
         else if s_index str index == closeTagChar
                then pure (Right index)
                else let afterAttrName = parseName str index
+#ifdef WHITESPACE_AROUND_EQUALS
                         beforeEquals = skipSpaces str afterAttrName
                     in if s_index str beforeEquals == equalChar
                          then let quoteIndex = skipSpaces str (beforeEquals + 1)
+#else
+                    in if s_index str afterAttrName == equalChar
+                         then let quoteIndex = afterAttrName + 1
+#endif
                                   usedChar = s_index str quoteIndex
                               in if usedChar == quoteChar ||
                                     usedChar == doubleQuoteChar

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,13 +1,9 @@
 # resolver: lts-7.24
 resolver: lts-11.8
 # resolver: nightly-2018-05-10
-packages:
-- .
-- location:
-    git: https://github.com/chrisdone/hexml.git
-    commit: 22923b55ca7390f1973ddfd0d0e517f13cf8a8a4
-  extra-dep: True
 extra-deps:
+- git: https://github.com/chrisdone/hexml.git
+  commit: 22923b55ca7390f1973ddfd0d0e517f13cf8a8a4
 - hexpat-0.20.9
 - List-0.5.2
 - libxml-0.1.1

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Simple test suite.
@@ -45,8 +46,13 @@ spec = do
   describe
     "hexml tests"
     (do mapM_
-          (\(v, i) -> it (show i) (shouldBe (validate i) v))
-          (hexml_examples_sax  ++ extra_examples_sax  ++ ws_around_equals_sax)
+          (\(v, i) -> it (show i) (shouldBe (validate i) v)) $ concat
+          [ hexml_examples_sax
+          , extra_examples_sax
+#ifdef WHITESPACE_AROUND_EQUALS
+          , ws_around_equals_sax
+#endif
+          ]
         mapM_
           (\(v, i) -> it (show i) (shouldBe (either (Left . show) (Right . id) (contents <$> parse i)) v))
           cdata_tests

--- a/xeno.cabal
+++ b/xeno.cabal
@@ -23,6 +23,10 @@ flag libxml2
   description:   Include libxml2 in the benchmarks
   default:       False
 
+flag whitespace-around-equals
+  description:   Correctly parse whitespace around the = characters in attribute definitions
+  default:       False
+
 library
   hs-source-dirs: src
   ghc-options: -Wall -O2
@@ -33,6 +37,8 @@ library
                -- , exceptions
                -- | DEBUG 
                , hspec
+  if flag(whitespace-around-equals)
+    cpp-options: -DWHITESPACE_AROUND_EQUALS
   default-language: Haskell2010
 
 test-suite xeno-test
@@ -44,6 +50,8 @@ test-suite xeno-test
                -- | DEBUG 
                , hspec
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
+  if flag(whitespace-around-equals)
+    cpp-options: -DWHITESPACE_AROUND_EQUALS
   default-language: Haskell2010
 
 benchmark xeno-speed-bench


### PR DESCRIPTION
Introduces a `whitespace-around-equals` CPP flag to allow the consumers of the library to decide whether they would like to take a performance hit in exchange for correctly parsing whitespace around `=` characters in attribute definitions.

See #22, #19.