### PR TITLE
Whitespace around equals #19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ before_install:
 # around some quirks in Travis's terminal implementation.
 script:
   - stack $ARGS --no-terminal --install-ghc test --haddock
-  # - stack bench
 
 # Caching so the next build will be fast too.
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ addons:
 # The different configurations we want to test. You could also do things like
 # change flags or use --stack-yaml to point to a different file.
 env:
-# - ARGS=""
-# #- ARGS="--resolver lts-2"
-# - ARGS="--resolver lts-3"
 - ARGS="--resolver lts"
 - ARGS="--resolver nightly"
 - ARGS="--resolver lts-7.2"
@@ -32,7 +29,7 @@ before_install:
 # around some quirks in Travis's terminal implementation.
 script:
   - stack $ARGS --no-terminal --install-ghc test --haddock
-  - stack bench
+  # - stack bench
 
 # Caching so the next build will be fast too.
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
 # around some quirks in Travis's terminal implementation.
 script:
   - stack $ARGS --no-terminal --install-ghc test --haddock
+  - stack bench
 
 # Caching so the next build will be fast too.
 cache:

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,9 @@
+	0.3.4
+	* Fixed #14 and add test for #15
+	* Fixed typos in the examples (unhammer)
+
 	0.3.2
-	Fixed DOM parsing from bystrings with non-zero offset (qrilka)
+	Fixed DOM parsing from bystrings with non-zero offset (#11, qrilka)
 	
 	0.3
 	Fixed name parsing (for attributes and tags) so it conforms with the XML spec (qrilka)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,4 +10,6 @@ Andreas Ekeroot ( Rembane )
 
 Kirill Zaborsky ( qrilka )
 
+Kevin Brubeck Unhammer ( unhammer )
+
 

--- a/src/Xeno/SAX.hs
+++ b/src/Xeno/SAX.hs
@@ -19,7 +19,6 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Unsafe as SU
-import           Data.Either (isRight)
 import           Data.Functor.Identity
 import           Data.Monoid
 import           Data.Word

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,6 @@
-resolver: lts-7.24
+# resolver: lts-7.24
+resolver: lts-11.8
+# resolver: nightly-2018-05-10
 packages:
 - .
 - location:

--- a/xeno.cabal
+++ b/xeno.cabal
@@ -1,5 +1,5 @@
 name: xeno
-version: 0.3.3
+version: 0.3.4
 synopsis: A fast event-based XML parser in pure Haskell
 description: A fast, low-memory use, event-based XML parser in pure Haskell.  
 build-type: Simple
@@ -10,7 +10,7 @@ license: BSD3
 license-file: LICENSE
 author: Christopher Done
 maintainer: Marco Zocca (zocca.marco gmail)
-tested-with:         GHC == 8.0.1
+tested-with:         GHC == 8.0.1, GHC == 8.2.2, GHC == 8.4.2
 extra-source-files:  README.md
                      CHANGELOG.markdown
                      CONTRIBUTORS.md                             


### PR DESCRIPTION
This PR introduces a flag to correctly parse whitespace around the = characters in attribute definitions.