### PR TITLE
Compatibility with bytestring 11

### DIFF
--- a/src/Xeno/DOM/Robust.hs
+++ b/src/Xeno/DOM/Robust.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE CPP                        #-}
 -- | DOM parser and API for XML.
 --   Slightly slower DOM parsing,
 --   but add missing close tags.
@@ -18,14 +19,20 @@ module Xeno.DOM.Robust
 
 import           Control.Monad.ST
 import           Control.Spork
+#if MIN_VERSION_bytestring(0,11,0)
 import           Data.ByteString.Internal as BS (ByteString(..), plusForeignPtr)
+#else
+import           Data.ByteString.Internal(ByteString(..))
+#endif
 import           Data.STRef
 import qualified Data.Vector.Unboxed         as UV
 import qualified Data.Vector.Unboxed.Mutable as UMV
 import           Data.Mutable(asURef, newRef, readRef, writeRef)
+#if MIN_VERSION_bytestring(0,11,0)
 import           Foreign.Ptr (minusPtr)
 import           Foreign.ForeignPtr (ForeignPtr, withForeignPtr)
 import           System.IO.Unsafe (unsafeDupablePerformIO)
+#endif
 import           Xeno.SAX
 import           Xeno.Types
 import           Xeno.DOM.Internal(Node(..), Content(..), name, attributes, contents, children)
@@ -48,7 +55,11 @@ parse inp =
           -- characters
           Just 0x1 -> go (n+3)
           _ -> Nothing
+#if MIN_VERSION_bytestring(0,11,0)
     BS offset0 _ = str
+#else
+    PS _ offset0 _ = str
+#endif
     str = skipDoctype inp
     node =
       runST
@@ -57,7 +68,11 @@ parse inp =
             sizeRef   <- fmap asURef $ newRef 0
             parentRef <- fmap asURef $ newRef 0
             process Process {
+#if MIN_VERSION_bytestring(0,11,0)
                 openF = \(BS name_start name_len) -> do
+#else
+                openF = \(PS _ name_start name_len) -> do
+#endif
                  let tag = 0x00
                      tag_end = -1
                  index <- readRef sizeRef
@@ -74,10 +89,14 @@ parse inp =
                     writeRef sizeRef (index + 5)
                     UMV.write v' index tag
                     UMV.write v' (index + 1) tag_parent
-                    UMV.write v' (index + 2) (minusForeignPtr name_start offset0)
+                    UMV.write v' (index + 2) (distance name_start offset0)
                     UMV.write v' (index + 3) name_len
                     UMV.write v' (index + 4) tag_end
+#if MIN_VERSION_bytestring(0,11,0)
               , attrF = \(BS key_start key_len) (BS value_start value_len) -> do
+#else
+              , attrF = \(PS _ key_start key_len) (PS _ value_start value_len) -> do
+#endif
                  index <- readRef sizeRef
                  v' <-
                    do v <- readSTRef vecRef
@@ -90,12 +109,16 @@ parse inp =
                  let tag = 0x02
                  do writeRef sizeRef (index + 5)
                  do UMV.write v' index tag
-                    UMV.write v' (index + 1) (minusForeignPtr key_start offset0)
+                    UMV.write v' (index + 1) (distance key_start offset0)
                     UMV.write v' (index + 2) key_len
-                    UMV.write v' (index + 3) (minusForeignPtr value_start offset0)
+                    UMV.write v' (index + 3) (distance value_start offset0)
                     UMV.write v' (index + 4) value_len
               , endOpenF = \_ -> return ()
+#if MIN_VERSION_bytestring(0,11,0)
               , textF = \(BS text_start text_len) -> do
+#else
+              , textF = \(PS _ text_start text_len) -> do
+#endif
                  let tag = 0x01
                  index <- readRef sizeRef
                  v' <-
@@ -108,9 +131,13 @@ parse inp =
                           return v'
                  do writeRef sizeRef (index + 3)
                  do UMV.write v' index tag
-                    UMV.write v' (index + 1) (minusForeignPtr text_start offset0)
+                    UMV.write v' (index + 1) (distance text_start offset0)
                     UMV.write v' (index + 2) text_len
+#if MIN_VERSION_bytestring(0,11,0)
               , closeF = \closeTag@(BS _ _) -> do
+#else
+              , closeF = \closeTag@(PS s _ _) -> do
+#endif
                  v <- readSTRef vecRef
                  -- Set the tag_end slot of the parent.
                  index <- readRef sizeRef
@@ -121,14 +148,22 @@ parse inp =
                                     else do
                                       parent_name <- UMV.read v (parent + 2)
                                       parent_len  <- UMV.read v (parent + 3)
+#if MIN_VERSION_bytestring(0,11,0)
                                       let openTag  = BS (BS.plusForeignPtr offset0 parent_name) parent_len
+#else
+                                      let openTag  = PS s (parent_name+offset0) parent_len
+#endif
                                       return       $ openTag == closeTag
                    UMV.write                  v (parent + 4) index
                    -- Pop the stack and return to the parent element.
                    previousParent <- UMV.read v (parent + 1)
                    writeRef parentRef previousParent
                    return correctTag -- continue closing tags, until matching one is found
+#if MIN_VERSION_bytestring(0,11,0)
               , cdataF = \(BS cdata_start cdata_len) -> do
+#else
+              , cdataF = \(PS _ cdata_start cdata_len) -> do
+#endif
                  let tag = 0x03
                  index <- readRef sizeRef
                  v' <-
@@ -141,7 +176,7 @@ parse inp =
                           return v'
                  do writeRef sizeRef (index + 3)
                  do UMV.write v' index tag
-                    UMV.write v' (index + 1) (minusForeignPtr cdata_start offset0)
+                    UMV.write v' (index + 1) (distance cdata_start offset0)
                     UMV.write v' (index + 2) cdata_len
               } str
             wet <- readSTRef vecRef
@@ -156,7 +191,15 @@ untilM loop = do
     True  -> return ()
     False -> untilM loop
 
+#if MIN_VERSION_bytestring(0,11,0)
 minusForeignPtr :: ForeignPtr a -> ForeignPtr b -> Int
 minusForeignPtr fpA fpB = unsafeDupablePerformIO $
   withForeignPtr fpA $ \ptrA -> withForeignPtr fpB $ \ptrB ->
     pure (minusPtr ptrA ptrB)
+
+distance :: ForeignPtr a -> ForeignPtr b -> Int
+distance = minusForeignPtr
+#else
+distance :: Int -> Int -> Int
+distance a b = a - b
+#endif

--- a/src/Xeno/Errors.hs
+++ b/src/Xeno/Errors.hs
@@ -34,6 +34,7 @@ bshow :: Show a => a -> BS.ByteString
 bshow = BS.pack . show
 
 {-# INLINE CONLIKE getStartIndex #-}
+-- FIXME remove this; there's no offset in the bytestring.
 getStartIndex :: BS.ByteString -> Int
 getStartIndex (PS _ from _) = from
 
@@ -54,8 +55,9 @@ displayException _      err                        = bshow err
 
 -- | Take n last bytes.
 revTake :: Int -> BS.ByteString -> BS.ByteString
-revTake i (PS ptr from to) = PS ptr (end-len) len
+revTake i bs =
+    if i >= len
+    then bs
+    else BS.drop (len - i) bs
   where
-    end = from + to
-    len = min to i
-
+    len = fromIntegral (BS.length bs)

--- a/xeno.cabal
+++ b/xeno.cabal
@@ -1,5 +1,5 @@
 name: xeno
-version: 0.4.2
+version: 0.5.0
 synopsis: A fast event-based XML parser in pure Haskell
 description: A fast, low-memory use, event-based XML parser in pure Haskell.  
 build-type: Simple
@@ -35,7 +35,7 @@ library
                    
   other-modules: Control.Spork
   build-depends: base >= 4.7 && < 5
-               , bytestring >= 0.10.8
+               , bytestring >= 0.11
                , vector >= 0.11
                , deepseq >= 1.4.2
                , array >= 0.5.1

--- a/xeno.cabal
+++ b/xeno.cabal
@@ -1,5 +1,5 @@
 name: xeno
-version: 0.5.0
+version: 0.5
 synopsis: A fast event-based XML parser in pure Haskell
 description: A fast, low-memory use, event-based XML parser in pure Haskell.  
 build-type: Simple
@@ -35,7 +35,7 @@ library
                    
   other-modules: Control.Spork
   build-depends: base >= 4.7 && < 5
-               , bytestring >= 0.11
+               , bytestring >= 0.10.8
                , vector >= 0.11
                , deepseq >= 1.4.2
                , array >= 0.5.1


### PR DESCRIPTION
ByteString no longer keeps an offset. The pattern synonym PS always
gives 0 for the offset. This means the parser definitions here in xeno
have become wrong. Tests were failing. This patch makes tests pass
giving me some confidence that it's the right fix.

Bumped the bytestring lower bound and also the xeno version.
