### PR TITLE
Prepare for MonadFail/ST instance removal from base

### DIFF
--- a/src/Xeno/SAX.hs
+++ b/src/Xeno/SAX.hs
@@ -138,7 +138,7 @@ validateEx s =
                s)
             readSTRef tags >>= \case
                 [] -> return ()
-                tags' -> fail $ "Not all tags closed: " ++ show tags'
+                tags' -> error $ "Not all tags closed: " ++ show tags'
          ) of
     Left (_ :: XenoException) -> False
     Right _ -> True


### PR DESCRIPTION
CLC has approved the proposal to remove the `ST` instance of `MonadFail` from `base`
(https://github.com/haskell/core-libraries-committee/issues/33).

 The implementation of the proposal is delayed to GHC 9.4,
 but one can already future-proof code to be
 compliant with this change in a backwards-compatible way. No CPP required.

Migration guide and more info:
https://github.com/haskell/core-libraries-committee/blob/main/guides/no-monadfail-st-inst.md