### PR TITLE
Swap out `mutable-containers` dependency for `unboxed-ref`

### DIFF
--- a/xeno.cabal
+++ b/xeno.cabal
@@ -39,7 +39,7 @@ library
                , vector >= 0.11
                , deepseq >= 1.4.2
                , array >= 0.5.1
-               , mutable-containers >= 0.3.3
+               , unboxed-ref >= 0.4 && < 0.5
                , mtl >= 2.2.1
   if flag(whitespace-around-equals)
     cpp-options: -DWHITESPACE_AROUND_EQUALS


### PR DESCRIPTION
Hi! I've prepared a PR to swap out the `mutable-containers` dependency for `unboxed-ref`, in case the maintainers here are interested.

The primary motivation is to reduce the dependency footprint.

Before:

![image](https://user-images.githubusercontent.com/1074598/205111968-b75f3848-57e4-4cfb-a587-acdc2f051b4e.png)

After:

![image](https://user-images.githubusercontent.com/1074598/205112087-26158734-56a0-4e40-998b-65396db99b95.png)

Although the `unboxed-ref` source has not been touched in 5+ years, I checked out the implementation and it looks solid. It also doesn't have any out-of-date dependencies on Hackage.