### PR TITLE
Add `skipXml` function to the Xeno.SAX module

### DIFF
--- a/src/Xeno/SAX.hs
+++ b/src/Xeno/SAX.hs
@@ -15,6 +15,7 @@ module Xeno.SAX
   , validateEx
   , dump
   , skipDoctype
+  , skipXml
   ) where
 
 import           Control.Exception (throw)
@@ -503,8 +504,15 @@ closeAngleBracketChar = 93
 
 -- | Skip initial DOCTYPE declaration
 skipDoctype :: ByteString -> ByteString
-skipDoctype arg =
-    if "<!DOCTYPE" `S8.isPrefixOf` bs
+skipDoctype = skipTag "<!DOCTYPE" 
+
+-- | Skip initial ?xml declaration
+skipXml :: BS.ByteString -> BS.ByteString
+skipXml = skipTag "<?xml"
+
+skipTag :: BS.ByteString -> BS.ByteString -> BS.ByteString
+skipTag tag arg =
+    if tag `S8.isPrefixOf` bs
       then let (_, rest)=">" `S8.breakSubstring` bs
            in skipBlanks $ S8.drop 1 rest
       else bs


### PR DESCRIPTION
`graphviz` generates following SVG file header:
```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
 "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
```
So, I can't drop DOCTYPE tag without dropping ?xml tag. 

That may be useful for other users, so I propose this function to be in the library.